### PR TITLE
Fix malformed triggers in mails config

### DIFF
--- a/General/mails.yml
+++ b/General/mails.yml
@@ -28,7 +28,7 @@ matches:
           cmd: "(Get-Date).Year"
 
   - triggers:
-      -  ":cot "
+      - ":cot "
       - "cot_ "
       - ":cotizacion "
       - "cotizacion_ "
@@ -55,7 +55,7 @@ matches:
       - ":invoice "
       - "invoice_ "
       - ":inv "
-      - "inv_   "
+      - "inv_ "
     label: "Email: invoice"
     replace: |
       Good day, and warm regards.


### PR DESCRIPTION
## Summary
- remove extra space from Spanish `:cot` trigger
- correct `inv_` trigger spacing for invoice email snippet

## Testing
- `yamllint -d '{extends: default, rules: {document-start: disable, line-length: disable, new-lines: disable, trailing-spaces: disable, hyphens: {max-spaces-after: 1}}}' General/mails.yml`

------
https://chatgpt.com/codex/tasks/task_e_689af3e8fdf8833382fc32142aa6c5b3