### PR TITLE
docs: comment shortcuts

### DIFF
--- a/General/ShortcutsEn.yml
+++ b/General/ShortcutsEn.yml
@@ -1,137 +1,138 @@
+---
 matches:
-    - trigger: ":th "
+    - trigger: ":th "  # express gratitude
       label: "Shortcut: Thank You!"
       replace: "Thank you!"
 
-    - trigger: ":gd "
+    - trigger: ":gd "  # greet someone with good day
       label: "Shortcut: Good Day"
       replace: "Hello, Good Day, "
 
-    - trigger: ":gm "
+    - trigger: ":gm "  # morning greeting
       label: "Shortcut: Good Morning"
       replace: "Good morning, "
 
-    - trigger: ":gn "
+    - trigger: ":gn "  # nightly farewell
       label: "Shortcut: Good Night"
       replace: "Good night, "
 
-    - trigger: ":ga "
+    - trigger: ":ga "  # afternoon greeting
       label: "Shortcut: Good Afternoon"
       replace: "Good afternoon, "
 
-    - trigger: ":ge "
+    - trigger: ":ge "  # evening greeting
       label: "Shortcut: Good Evening"
       replace: "Good evening, "
 
-    - trigger: ":hi "
+    - trigger: ":hi "  # casual hello
       label: "Shortcut: Hello"
       replace: "Hello, "
 
 
-    - trigger: ":yw "
+    - trigger: ":yw "  # respond with you're welcome
       label: "Shortcut: You're Welcome!"
       replace: "You're welcome!"
 
-    - trigger: ":np "
+    - trigger: ":np "  # reassure no problem
       label: "Shortcut: No Problem!"
       replace: "No problem!"
 
-    - trigger: ":pls "
+    - trigger: ":pls "  # polite please
       label: "Shortcut: Please"
       replace: "Please"
 
-    - trigger: ":fyi "
+    - trigger: ":fyi "  # share for your information
       label: "Shortcut: For Your Information"
       replace: "For your information"
 
-    - trigger: ":asap "
+    - trigger: ":asap "  # request urgency
       label: "Shortcut: As Soon As Possible"
       replace: "As soon as possible"
 
-    - trigger: ":thx "
+    - trigger: ":thx "  # quick thanks
       label: "Shortcut: Thanks!"
       replace: "Thanks!"
 
-    - trigger: ":q "
+    - trigger: ":q "  # introduce a question
       label: "Shortcut: Question"
       replace: "Question:"
 
-    - trigger: ":sug "
+    - trigger: ":sug "  # introduce a suggestion
       label: "Shortcut: Suggestion"
       replace: "Suggestion:"
 
-    - trigger: ":delay "
+    - trigger: ":delay "  # apologize for delay
       label: "Shortcut: Apologies for Delay"
       replace: "Apologies for the delay."
 
-    - trigger: ":sb "
+    - trigger: ":sb "  # indicate standby
       label: "Shortcut: Standing By"
       replace: "I'll be standing by for anything you need."
 
-    - trigger: ":ok "
+    - trigger: ":ok "  # simple acknowledgment
       label: "Shortcut: Okay"
       replace: "Okay"
 
-    - trigger: ":brb "
+    - trigger: ":brb "  # step away briefly
       label: "Shortcut: Be Right Back"
       replace: "Be right back."
 
-    - trigger: ":thxm "
+    - trigger: ":thxm "  # express big thanks
       label: "Shortcut: Thank You So Much!"
       replace: "Thank you so much!"
 
-    - trigger: ":lmk "
+    - trigger: ":lmk "  # ask to let you know
       label: "Shortcut: Let Me Know"
       replace: "Let me know if you have any questions."
 
-    - trigger: ":np "
+    - trigger: ":np "  # reassure no problem at all
       label: "Shortcut: No Problem at all!"
       replace: "No problem at all!"
 
-    - trigger: ":urw "
+    - trigger: ":urw "  # warmly you're welcome
       label: "Shortcut: You're Very Welcome"
       replace: "You're very welcome."
 
-    - trigger: ":gtg "
+    - trigger: ":gtg "  # need to leave
       label: "Shortcut: Got To Go"
       replace: "Got to go, talk soon!"
 
-    - trigger: ":idk "
+    - trigger: ":idk "  # express uncertainty
       label: "Shortcut: I Don't Know"
       replace: "I Don't Know, I'm not sure…"
 
-    - trigger: ":ack "
+    - trigger: ":ack "  # acknowledge receipt
       label: "Shortcut: Acknowledged"
       replace: "Acknowledged!"
 
-    - trigger: ":tyfw "
+    - trigger: ":tyfw "  # thank for waiting
       label: "Shortcut: Thank You for Waiting"
       replace: "Thank You for waiting, and for your patience."
 
-    - trigger: ":wait "
+    - trigger: ":wait "  # ask to wait a moment
       label: "Shortcut: Wait a Moment"
       replace: "Excuse me, Please wait a just a moment."
 
-    - trigger: ":thxa "
+    - trigger: ":thxa "  # thank everyone
       label: "Shortcut: Thank You All"
       replace: "Thank you all!"
 
-    - trigger: ":gn "
+    - trigger: ":gn "  # wish good night
       label: "Shortcut: Good Night"
       replace: "Good night, talk soon."
 
-    - trigger: ":glhf "
+    - trigger: ":glhf "  # wish luck and fun
       label: "Shortcut: Good Luck, Have Fun"
       replace: "Good luck and have fun!"
 
-    - trigger: ":imo "
+    - trigger: ":imo "  # share opinion
       label: "Shortcut: In My Opinion"
       replace: "In my opinion, "
 
-    - trigger: ":btw "
+    - trigger: ":btw "  # add by the way
       label: "Shortcut: By The Way"
       replace: "By the way, "
 
-    - trigger: ":onit "
+    - trigger: ":onit "  # indicate you are on it
       label: "Shortcut: On It"
       replace: "I'm on it, I'll take care of this right away."

--- a/General/ShortcutsEs.yml
+++ b/General/ShortcutsEs.yml
@@ -1,133 +1,134 @@
+---
 matches:
-  - trigger: ":th_ "
+  - trigger: ":th_ "  # expresión de agradecimiento
     label: "Atajo: ¡Gracias!"
     replace: "¡Gracias!"
 
-  - trigger: ":gd_ "
+  - trigger: ":gd_ "  # saludo de buen día
     label: "Atajo: Hola, buen día"
     replace: "Hola, buen día, "
 
-  - trigger: ":gm_ "
+  - trigger: ":gm_ "  # saludo matutino
     label: "Atajo: Buenos días"
     replace: "Buenos días, "
 
-  - trigger: ":gn_ "
+  - trigger: ":gn_ "  # despedida nocturna
     label: "Atajo: Buenas noches"
     replace: "Buenas noches, "
 
-  - trigger: ":ga_ "
+  - trigger: ":ga_ "  # saludo vespertino
     label: "Atajo: Buenas tardes"
     replace: "Buenas tardes, "
 
-  - trigger: ":ge_ "
+  - trigger: ":ge_ "  # saludo de tarde-noche
     label: "Atajo: Buenas tardes/noches"
     replace: "Buenas tardes o casi noches, "
 
-  - trigger: ":hi_ "
+  - trigger: ":hi_ "  # saludo casual
     label: "Atajo: Hola"
     replace: "Hola, "
 
 
-  - trigger: ":yw_ "
+  - trigger: ":yw_ "  # responder de nada
     label: "Atajo: ¡De nada!"
     replace: "¡De nada!"
 
-  - trigger: ":urw_ "
+  - trigger: ":urw_ "  # respuesta más cordial
     label: "Atajo: De nada, muy amable"
     replace: "De nada, muy amable."
 
-  - trigger: ":np_ "
+  - trigger: ":np_ "  # asegurar que no hay problema
     label: "Atajo: ¡No hay problema!"
     replace: "¡No hay problema!"
 
-  - trigger: ":npa_ "
+  - trigger: ":npa_ "  # enfatizar que no hay problema
     label: "Atajo: ¡Ningún problema en absoluto!"
     replace: "¡Ningún problema en absoluto!"
 
-  - trigger: ":pls_ "
+  - trigger: ":pls_ "  # pedir por favor
     label: "Atajo: Por favor"
     replace: "Por favor"
 
-  - trigger: ":fyi_ "
+  - trigger: ":fyi_ "  # compartir información
     label: "Atajo: Para tu información"
     replace: "Para tu información"
 
-  - trigger: ":asap_ "
+  - trigger: ":asap_ "  # pedir urgencia
     label: "Atajo: Lo antes posible"
     replace: "Lo antes posible"
 
-  - trigger: ":thx_ "
+  - trigger: ":thx_ "  # gracias abreviado
     label: "Atajo: ¡Gracias!"
     replace: "¡Gracias!"
 
-  - trigger: ":thxm_ "
+  - trigger: ":thxm_ "  # agradecimiento grande
     label: "Atajo: ¡Muchísimas gracias!"
     replace: "¡Muchísimas gracias!"
 
-  - trigger: ":thxa_ "
+  - trigger: ":thxa_ "  # agradecer a todos
     label: "Atajo: ¡Gracias a todos!"
     replace: "¡Gracias a todos!"
 
-  - trigger: ":q_ "
+  - trigger: ":q_ "  # introducir una pregunta
     label: "Atajo: Pregunta"
     replace: "Pregunta:"
 
-  - trigger: ":sug_ "
+  - trigger: ":sug_ "  # introducir una sugerencia
     label: "Atajo: Sugerencia"
     replace: "Sugerencia:"
 
-  - trigger: ":delay_ "
+  - trigger: ":delay_ "  # disculpa por la demora
     label: "Atajo: Disculpa la demora"
     replace: "Disculpa la demora."
 
-  - trigger: ":sb_ "
+  - trigger: ":sb_ "  # indicar que quedas pendiente
     label: "Atajo: Quedo pendiente"
     replace: "Quedo pendiente de cualquier cosa que necesites."
 
-  - trigger: ":ok_ "
+  - trigger: ":ok_ "  # simple ok
     label: "Atajo: Ok"
     replace: "Ok"
 
-  - trigger: ":brb_ "
+  - trigger: ":brb_ "  # me ausento un momento
     label: "Atajo: Vuelvo enseguida"
     replace: "Vuelvo enseguida."
 
-  - trigger: ":lmk_ "
+  - trigger: ":lmk_ "  # hazme saber
     label: "Atajo: Hazme saber"
     replace: "Hazme saber si tienes alguna pregunta."
 
-  - trigger: ":gtg_ "
+  - trigger: ":gtg_ "  # debo irme
     label: "Atajo: Me tengo que ir"
     replace: "Me tengo que ir, hablamos pronto."
 
-  - trigger: ":idk_ "
+  - trigger: ":idk_ "  # expresar duda
     label: "Atajo: No sé"
     replace: "No sé, no estoy seguro…"
 
-  - trigger: ":ack_ "
+  - trigger: ":ack_ "  # confirmar entendido
     label: "Atajo: Entendido"
     replace: "Entendido."
 
-  - trigger: ":tyfw_ "
+  - trigger: ":tyfw_ "  # agradecer la espera
     label: "Atajo: Gracias por esperar"
     replace: "Gracias por esperar y por tu paciencia."
 
-  - trigger: ":wait_ "
+  - trigger: ":wait_ "  # pedir que espere
     label: "Atajo: Espera un momento"
     replace: "Disculpa, por favor espera un momento."
 
-  - trigger: ":glhf_ "
+  - trigger: ":glhf_ "  # desear suerte y diversión
     label: "Atajo: ¡Buena suerte, diviértete!"
     replace: "¡Buena suerte y diviértete!"
 
-  - trigger: ":imo_ "
+  - trigger: ":imo_ "  # expresar opinión
     label: "Atajo: En mi opinión"
     replace: "En mi opinión, "
 
-  - trigger: ":btw_ "
+  - trigger: ":btw_ "  # añadir por cierto
     label: "Atajo: Por cierto"
     replace: "Por cierto, "
 
-  - trigger: ":onit_ "
+  - trigger: ":onit_ "  # indicar que te encargas
     label: "Atajo: Me encargo de esto"
     replace: "Me encargo de esto, lo atenderé de inmediato."


### PR DESCRIPTION
## Summary
- add brief comments to English shortcut triggers
- annotate Spanish shortcut triggers for clarity

## Testing
- `yamllint General/ShortcutsEn.yml General/ShortcutsEs.yml`

------
https://chatgpt.com/codex/tasks/task_e_689af433f5e48333af3d278892537075