### PR TITLE
docs: fix sync command block

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@ To link this GitHub repo (`A:\test\Espanso`) with your Espanso match folder (`C:
 
 ```cmd
 rmdir "C:\Users\Julibe\AppData\Roaming\espanso\match"
-mklink /J "C:\Users\Julibe\AppData\Roaming\espanso\match" "A:\test\Espanso
+mklink /J "C:\Users\Julibe\AppData\Roaming\espanso\match" "A:\test\Espanso"
 ```


### PR DESCRIPTION
## Summary
- complete `mklink` command in README sync instructions
- close code block properly

## Testing
- `npx --yes markdownlint-cli README.md` *(fails: MD022, MD013, MD012)*

------
https://chatgpt.com/codex/tasks/task_e_689af9645ae48333870b19f9b5291c19