### PR TITLE
fix: correct wait shortcut grammar

### DIFF
--- a/General/ShortcutsEn.yml
+++ b/General/ShortcutsEn.yml
@@ -111,7 +111,7 @@ matches:
 
     - trigger: ":wait "  # ask to wait a moment
       label: "Shortcut: Wait a Moment"
-      replace: "Excuse me, Please wait a just a moment."
+      replace: "Excuse me, please wait just a moment."
 
     - trigger: ":thxa "  # thank everyone
       label: "Shortcut: Thank You All"


### PR DESCRIPTION
## Summary
- fix wait shortcut text to use proper grammar

## Testing
- `yamllint General/ShortcutsEn.yml`


------
https://chatgpt.com/codex/tasks/task_e_689af969e4a88333b7991e8701a4cbf4