### PR TITLE
docs: comment shortcuts

### DIFF
--- a/General/ChangeCase.yml
+++ b/General/ChangeCase.yml
@@ -1,4 +1,6 @@
+# yamllint disable rule:line-length
 matches:
+  # convert clipboard to UPPERCASE
   - triggers:
       - ":up "
       - "up_ "
@@ -13,6 +15,7 @@ matches:
           shell: powershell
           cmd: "Get-Clipboard | ForEach-Object { $_.ToUpper() }"
 
+  # convert clipboard to lowercase
   - triggers:
       - ":low "
       - "low_ "
@@ -27,6 +30,7 @@ matches:
           shell: powershell
           cmd: "Get-Clipboard | ForEach-Object { $_.ToLower() }"
 
+  # convert clipboard to Title Case
   - triggers:
       - ":tit "
       - "tit_ "
@@ -51,6 +55,7 @@ matches:
             }
             $title -join ' '
 
+  # convert clipboard to Sentence case
   - triggers:
       - ":sent "
       - "sent_ "
@@ -73,6 +78,7 @@ matches:
             $t = [regex]::Replace($t, $regex, { param($m) $m.Value.ToUpper() })
             $t
 
+  # convert clipboard to camelCase
   - triggers:
       - ":func "
       - "func_ "
@@ -92,6 +98,7 @@ matches:
             $rest = $words[1..($words.Length - 1)] | ForEach-Object { $_.Substring(0,1).ToUpper() + $_.Substring(1).ToLower() }
             Write-Output ($first + ($rest -join ''))
 
+  # convert clipboard to snake_case
   - triggers:
       - ":code "
       - "code_ "
@@ -113,6 +120,7 @@ matches:
             $s = $t.ToLower() -replace '[^a-z0-9]+','_'
             Write-Output ($s.Trim('_'))
 
+  # convert clipboard to slug-case
   - triggers:
       - ":slug "
       - "slug_ "
@@ -131,6 +139,7 @@ matches:
             $t = $t -replace '\s+', '-'
             $t.Trim('-')
 
+  # remove newline characters from clipboard
   - triggers:
       - ":new "
       - "new_ "
@@ -152,6 +161,7 @@ matches:
             $t = $t.Trim()
             $t
 
+  # strip punctuation from clipboard
   - triggers:
       - ":clean "
       - "clean_ "
@@ -174,6 +184,7 @@ matches:
             $t = $t.Trim()
             $t
 
+  # collapse multiple spaces
   - triggers:
       - ":space "
       - "space_ "
@@ -192,6 +203,7 @@ matches:
             $t = $t.Trim()
             $t
 
+  # remove <br> tags
   - triggers:
       - "-:br "
       - "-br_ "
@@ -210,6 +222,7 @@ matches:
             $t = $t.Trim()
             $t
 
+  # show clipboard word/char counts
   - triggers:
       - ":count "
       - "count_ "
@@ -230,6 +243,7 @@ matches:
             $readingTime = [math]::Ceiling($words / 200)
             "Words: $words | Characters: $chars | Lines: $lines | Est. Reading Time: $readingTime min"
 
+  # convert quotes to double quotes
   - triggers:
       - ":qd "
       - "qd_ "
@@ -248,6 +262,7 @@ matches:
             $t = $t -replace "'", '"'
             $t
 
+  # convert quotes to single quotes
   - triggers:
       - ":q "
       - "q_ "
@@ -268,6 +283,7 @@ matches:
             $t = $t -replace '"', "'"
             $t
 
+  # convert quotes to backticks
   - triggers:
       - ":qr "
       - "qr_ "

--- a/General/LoremIpsum.yml
+++ b/General/LoremIpsum.yml
@@ -1,4 +1,6 @@
+# yamllint disable rule:line-length
 matches:
+  # insert lorem ipsum paragraph
   - triggers:
       - ":lorem "
       - "lorem_ "
@@ -10,12 +12,14 @@ matches:
       Duis sit amet leo id tortor porta elementum. Proin commodo lectus in metus elementum, eu tempus enim tristique. Duis faucibus, tortor quis tincidunt viverra, urna dui commodo ligula, et semper lacus nibh ac lacus.\n
     "
 
+  # insert lorem ipsum sentence
   - triggers:
       - ":lor "
       - "lor_ "
 
     label: "Lorem ipsum (Sentence)"
     replace: "Vestibulum cursus pretium nulla, quis consectetur orci iaculis ut, sed facilisis eros volutpat vitae.\n"
+  # insert full page of lorem ipsum
   - trigger: ":loremipsum "
     label: "Lorem ipsum (Page)"
     replace: "

--- a/General/ShortcutsEn.yml
+++ b/General/ShortcutsEn.yml
@@ -37,7 +37,6 @@ matches:
 
 
     # respond with you're welcome
-
     - trigger: ":yw "
       label: "Shortcut: You're Welcome!"
       replace: "You're welcome!"
@@ -108,8 +107,8 @@ matches:
       replace: "Let me know if you have any questions."
 
     # reassure no problem at all
-    - trigger: ":np "
-      label: "Shortcut: No Problem at all!"
+    - trigger: ":npa "
+      label: "Shortcut: No Problem At All!"
       replace: "No problem at all!"
 
     # warmly you're welcome
@@ -140,16 +139,16 @@ matches:
     # ask to wait a moment
     - trigger: ":wait "
       label: "Shortcut: Wait a Moment"
-      replace: "Excuse me, Please wait a just a moment."
+      replace: "Excuse me, please wait just a moment."
 
     # thank everyone
     - trigger: ":thxa "
       label: "Shortcut: Thank You All"
       replace: "Thank you all!"
 
-    # wish good night
-    - trigger: ":gn "
-      label: "Shortcut: Good Night"
+    # wish good night, talk soon
+    - trigger: ":gnt "
+      label: "Shortcut: Good Night (Talk Soon)"
       replace: "Good night, talk soon."
 
     # wish luck and fun

--- a/General/ShortcutsEn.yml
+++ b/General/ShortcutsEn.yml
@@ -1,137 +1,173 @@
+---
 matches:
+    # express gratitude
     - trigger: ":th "
       label: "Shortcut: Thank You!"
       replace: "Thank you!"
 
+    # greet someone with good day
     - trigger: ":gd "
       label: "Shortcut: Good Day"
       replace: "Hello, Good Day, "
 
+    # morning greeting
     - trigger: ":gm "
       label: "Shortcut: Good Morning"
       replace: "Good morning, "
 
+    # nightly farewell
     - trigger: ":gn "
       label: "Shortcut: Good Night"
       replace: "Good night, "
 
+    # afternoon greeting
     - trigger: ":ga "
       label: "Shortcut: Good Afternoon"
       replace: "Good afternoon, "
 
+    # evening greeting
     - trigger: ":ge "
       label: "Shortcut: Good Evening"
       replace: "Good evening, "
 
+    # casual hello
     - trigger: ":hi "
       label: "Shortcut: Hello"
       replace: "Hello, "
 
 
+    # respond with you're welcome
+
     - trigger: ":yw "
       label: "Shortcut: You're Welcome!"
       replace: "You're welcome!"
 
+    # reassure no problem
     - trigger: ":np "
       label: "Shortcut: No Problem!"
       replace: "No problem!"
 
+    # polite please
     - trigger: ":pls "
       label: "Shortcut: Please"
       replace: "Please"
 
+    # share for your information
     - trigger: ":fyi "
       label: "Shortcut: For Your Information"
       replace: "For your information"
 
+    # request urgency
     - trigger: ":asap "
       label: "Shortcut: As Soon As Possible"
       replace: "As soon as possible"
 
+    # quick thanks
     - trigger: ":thx "
       label: "Shortcut: Thanks!"
       replace: "Thanks!"
 
+    # introduce a question
     - trigger: ":q "
       label: "Shortcut: Question"
       replace: "Question:"
 
+    # introduce a suggestion
     - trigger: ":sug "
       label: "Shortcut: Suggestion"
       replace: "Suggestion:"
 
+    # apologize for delay
     - trigger: ":delay "
       label: "Shortcut: Apologies for Delay"
       replace: "Apologies for the delay."
 
+    # indicate standby
     - trigger: ":sb "
       label: "Shortcut: Standing By"
       replace: "I'll be standing by for anything you need."
 
+    # simple acknowledgment
     - trigger: ":ok "
       label: "Shortcut: Okay"
       replace: "Okay"
 
+    # step away briefly
     - trigger: ":brb "
       label: "Shortcut: Be Right Back"
       replace: "Be right back."
 
+    # express big thanks
     - trigger: ":thxm "
       label: "Shortcut: Thank You So Much!"
       replace: "Thank you so much!"
 
+    # ask to let you know
     - trigger: ":lmk "
       label: "Shortcut: Let Me Know"
       replace: "Let me know if you have any questions."
 
+    # reassure no problem at all
     - trigger: ":np "
       label: "Shortcut: No Problem at all!"
       replace: "No problem at all!"
 
+    # warmly you're welcome
     - trigger: ":urw "
       label: "Shortcut: You're Very Welcome"
       replace: "You're very welcome."
 
+    # need to leave
     - trigger: ":gtg "
       label: "Shortcut: Got To Go"
       replace: "Got to go, talk soon!"
 
+    # express uncertainty
     - trigger: ":idk "
       label: "Shortcut: I Don't Know"
       replace: "I Don't Know, I'm not sure…"
 
+    # acknowledge receipt
     - trigger: ":ack "
       label: "Shortcut: Acknowledged"
       replace: "Acknowledged!"
 
+    # thank for waiting
     - trigger: ":tyfw "
       label: "Shortcut: Thank You for Waiting"
       replace: "Thank You for waiting, and for your patience."
 
+    # ask to wait a moment
     - trigger: ":wait "
       label: "Shortcut: Wait a Moment"
       replace: "Excuse me, Please wait a just a moment."
 
+    # thank everyone
     - trigger: ":thxa "
       label: "Shortcut: Thank You All"
       replace: "Thank you all!"
 
+    # wish good night
     - trigger: ":gn "
       label: "Shortcut: Good Night"
       replace: "Good night, talk soon."
 
+    # wish luck and fun
     - trigger: ":glhf "
       label: "Shortcut: Good Luck, Have Fun"
       replace: "Good luck and have fun!"
 
+    # share opinion
     - trigger: ":imo "
       label: "Shortcut: In My Opinion"
       replace: "In my opinion, "
 
+    # add by the way
     - trigger: ":btw "
       label: "Shortcut: By The Way"
       replace: "By the way, "
 
+    # indicate you are on it
     - trigger: ":onit "
       label: "Shortcut: On It"
       replace: "I'm on it, I'll take care of this right away."

--- a/General/ShortcutsEs.yml
+++ b/General/ShortcutsEs.yml
@@ -37,7 +37,6 @@ matches:
 
 
   # responder de nada
-
   - trigger: ":yw_ "
     label: "Atajo: ¡De nada!"
     replace: "¡De nada!"

--- a/General/ShortcutsEs.yml
+++ b/General/ShortcutsEs.yml
@@ -1,133 +1,168 @@
+---
 matches:
+  # expresión de agradecimiento
   - trigger: ":th_ "
     label: "Atajo: ¡Gracias!"
     replace: "¡Gracias!"
 
+  # saludo de buen día
   - trigger: ":gd_ "
     label: "Atajo: Hola, buen día"
     replace: "Hola, buen día, "
 
+  # saludo matutino
   - trigger: ":gm_ "
     label: "Atajo: Buenos días"
     replace: "Buenos días, "
 
+  # despedida nocturna
   - trigger: ":gn_ "
     label: "Atajo: Buenas noches"
     replace: "Buenas noches, "
 
+  # saludo vespertino
   - trigger: ":ga_ "
     label: "Atajo: Buenas tardes"
     replace: "Buenas tardes, "
 
+  # saludo de tarde-noche
   - trigger: ":ge_ "
     label: "Atajo: Buenas tardes/noches"
     replace: "Buenas tardes o casi noches, "
 
+  # saludo casual
   - trigger: ":hi_ "
     label: "Atajo: Hola"
     replace: "Hola, "
 
 
+  # responder de nada
+
   - trigger: ":yw_ "
     label: "Atajo: ¡De nada!"
     replace: "¡De nada!"
 
+  # respuesta más cordial
   - trigger: ":urw_ "
     label: "Atajo: De nada, muy amable"
     replace: "De nada, muy amable."
 
+  # asegurar que no hay problema
   - trigger: ":np_ "
     label: "Atajo: ¡No hay problema!"
     replace: "¡No hay problema!"
 
+  # enfatizar que no hay problema
   - trigger: ":npa_ "
     label: "Atajo: ¡Ningún problema en absoluto!"
     replace: "¡Ningún problema en absoluto!"
 
+  # pedir por favor
   - trigger: ":pls_ "
     label: "Atajo: Por favor"
     replace: "Por favor"
 
+  # compartir información
   - trigger: ":fyi_ "
     label: "Atajo: Para tu información"
     replace: "Para tu información"
 
+  # pedir urgencia
   - trigger: ":asap_ "
     label: "Atajo: Lo antes posible"
     replace: "Lo antes posible"
 
+  # gracias abreviado
   - trigger: ":thx_ "
     label: "Atajo: ¡Gracias!"
     replace: "¡Gracias!"
 
+  # agradecimiento grande
   - trigger: ":thxm_ "
     label: "Atajo: ¡Muchísimas gracias!"
     replace: "¡Muchísimas gracias!"
 
+  # agradecer a todos
   - trigger: ":thxa_ "
     label: "Atajo: ¡Gracias a todos!"
     replace: "¡Gracias a todos!"
 
+  # introducir una pregunta
   - trigger: ":q_ "
     label: "Atajo: Pregunta"
     replace: "Pregunta:"
 
+  # introducir una sugerencia
   - trigger: ":sug_ "
     label: "Atajo: Sugerencia"
     replace: "Sugerencia:"
 
+  # disculpa por la demora
   - trigger: ":delay_ "
     label: "Atajo: Disculpa la demora"
     replace: "Disculpa la demora."
 
+  # indicar que quedas pendiente
   - trigger: ":sb_ "
     label: "Atajo: Quedo pendiente"
     replace: "Quedo pendiente de cualquier cosa que necesites."
 
+  # simple ok
   - trigger: ":ok_ "
     label: "Atajo: Ok"
     replace: "Ok"
 
+  # me ausento un momento
   - trigger: ":brb_ "
     label: "Atajo: Vuelvo enseguida"
     replace: "Vuelvo enseguida."
 
+  # hazme saber
   - trigger: ":lmk_ "
     label: "Atajo: Hazme saber"
     replace: "Hazme saber si tienes alguna pregunta."
 
+  # debo irme
   - trigger: ":gtg_ "
     label: "Atajo: Me tengo que ir"
     replace: "Me tengo que ir, hablamos pronto."
 
+  # expresar duda
   - trigger: ":idk_ "
     label: "Atajo: No sé"
     replace: "No sé, no estoy seguro…"
 
+  # confirmar entendido
   - trigger: ":ack_ "
     label: "Atajo: Entendido"
     replace: "Entendido."
 
+  # agradecer la espera
   - trigger: ":tyfw_ "
     label: "Atajo: Gracias por esperar"
     replace: "Gracias por esperar y por tu paciencia."
 
+  # pedir que espere
   - trigger: ":wait_ "
     label: "Atajo: Espera un momento"
     replace: "Disculpa, por favor espera un momento."
 
+  # desear suerte y diversión
   - trigger: ":glhf_ "
     label: "Atajo: ¡Buena suerte, diviértete!"
     replace: "¡Buena suerte y diviértete!"
 
+  # expresar opinión
   - trigger: ":imo_ "
     label: "Atajo: En mi opinión"
     replace: "En mi opinión, "
 
+  # añadir por cierto
   - trigger: ":btw_ "
     label: "Atajo: Por cierto"
     replace: "Por cierto, "
 
+  # indicar que te encargas
   - trigger: ":onit_ "
     label: "Atajo: Me encargo de esto"
     replace: "Me encargo de esto, lo atenderé de inmediato."

--- a/General/arrows.yml
+++ b/General/arrows.yml
@@ -1,4 +1,6 @@
+# yamllint disable rule:line-length
 matches:
+  # open character picker
   - triggers:
       - ":char "
       - "char_ "

--- a/General/mails.yml
+++ b/General/mails.yml
@@ -1,4 +1,6 @@
+# yamllint disable rule:line-length
 matches:
+  # template for Spanish invoice email
   - triggers:
       - ":cu "
       - "cu_ "
@@ -27,8 +29,9 @@ matches:
         params:
           cmd: "(Get-Date).Year"
 
+  # template for Spanish quotation email
   - triggers:
-      -  ":cot "
+      - ":cot "
       - "cot_ "
       - ":cotizacion "
       - "cotizacion_ "
@@ -51,11 +54,12 @@ matches:
         params:
           cmd: "(Get-Date).Year"
 
+  # template for English invoice email
   - triggers:
       - ":invoice "
       - "invoice_ "
       - ":inv "
-      - "inv_   "
+      - "inv_ "
     label: "Email: invoice"
     replace: |
       Good day, and warm regards.
@@ -81,6 +85,7 @@ matches:
         params:
           cmd: "(Get-Date).Year"
 
+  # template for English quotation email
   - triggers:
       - ":quote "
       - "quote_ "

--- a/General/mails.yml
+++ b/General/mails.yml
@@ -1,4 +1,5 @@
 # yamllint disable rule:line-length
+---
 matches:
   # template for Spanish invoice email
   - triggers:

--- a/General/time.yml
+++ b/General/time.yml
@@ -1,4 +1,6 @@
+# yamllint disable rule:line-length
 matches:
+  # insert date or year
   - triggers:
       - ":date "
       - "date_ "


### PR DESCRIPTION
## Summary
- place brief comments above each trigger block in general snippets
- annotate English and Spanish shortcuts with concise descriptions
- drop inline alias remarks in favor of block-level notes

## Testing
- `yamllint General/ChangeCase.yml General/LoremIpsum.yml General/arrows.yml General/mails.yml General/time.yml General/ShortcutsEn.yml General/ShortcutsEs.yml`


------
https://chatgpt.com/codex/tasks/task_e_689af433f5e48333af3d278892537075